### PR TITLE
$LXC_TIMEZONE instead of fixed Europe/Berlin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ else
  VLAN=""
 fi
 # Reconfigure conatiner
-pct set $LXC_NBR -memory $LXC_MEM -swap $LXC_SWAP -hostname $LXC_HOSTNAME \-nameserver $LXC_DNS -searchdomain $LXC_DOMAIN -onboot 1 -timezone Europe/Berlin -net0 name=eth0,bridge=$LXC_BRIDGE,firewall=1,gw=$LXC_GW,ip=$LXC_IP,type=veth$VLAN;
+pct set $LXC_NBR -memory $LXC_MEM -swap $LXC_SWAP -hostname $LXC_HOSTNAME \-nameserver $LXC_DNS -searchdomain $LXC_DOMAIN -onboot 1 -timezone $LXC_TIMEZONE -net0 name=eth0,bridge=$LXC_BRIDGE,firewall=1,gw=$LXC_GW,ip=$LXC_IP,type=veth$VLAN;
 sleep 2;
 
 PS3="Select the Server-Function: "


### PR DESCRIPTION
pct set ... change to use variable $LXC_TIMEZONE instead of fixed "Europe/Berlin".

P.S.: Is timezone parameter required when creating an LXC container or can it be left out entirely?