### PR TITLE
Update kimai

### DIFF
--- a/src/kimai/constants-service.conf
+++ b/src/kimai/constants-service.conf
@@ -11,7 +11,7 @@
 LXC_TEMPLATE_VERSION="debian-11-standard"
 
 # Create sharefs mountpoint
-LXC_MP="1"
+LXC_MP="0"
 
 # Create unprivileged container
 LXC_UNPRIVILEGED="1"

--- a/src/kimai/install-service.sh
+++ b/src/kimai/install-service.sh
@@ -150,13 +150,13 @@ APP_SECRET=$(random_password)
 CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
 EOF
 
-chown -R www-data:www-data .
-chmod -R g+r .
-chmod -R g+rw var/
-
 bin/console kimai:install -n
 
 bin/console kimai:user:create admin admin@$LXC_DOMAIN ROLE_SUPER_ADMIN $LXC_PWD
+
+chown -R www-data:www-data .
+chmod -R g+r .
+chmod -R g+rw var/
 
 systemctl daemon-reload
 systemctl enable --now php${PHP_VERSION}-fpm nginx


### PR DESCRIPTION
fix permissions error on install kimai
removed additional lxc mountpoint (LXC_MP="0") not needed

Tests:
- [x] fix permissions error on install kimai
- [x] removed additional lxc mountpoint (LXC_MP="0") not needed
