### PR TITLE
Add options for mount of host system folder and apt mirror setup.

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -12,6 +12,11 @@ Defines the Proxmox storage where your LXC container template are stored (defaul
 ```bash
 LXC_TEMPLATE_STORAGE="local"
 ```
+### LXC_TEMPLATE_SET_MIRROR
+Delault mirror setting for /etc/apt/sources.list (default: "", leaves the file unchanged)
+```bash
+LXC_TEMPLATE_SET_MIRROR=""
+```
 ### LXC_ROOTFS_SIZE
 Defines the size in GB of the LXC container's root filesystem (default: 32)
 ```bash
@@ -27,6 +32,11 @@ LXC_ROOTFS_STORAGE="local-zfs"
 Defines the size in GB your LXC container's filesystem shared by Zamba (AD member & standalone) (default: 100)
 ```bash
 LXC_SHAREFS_SIZE="100"
+```
+### LXC_SHAREFS_BINDMOUNT
+Defines a the host system folder to be bind-mounted and shared by Zamba. Requires LXC_SHAREFS_SIZE > 0 but ignores the value. (AD member & standalone) (default: "")
+```bash
+LXC_SHAREFS_BINDMOUNT="/host/folder"
 ```
 ### LXC_SHAREFS_STORAGE
 Defines the Proxmox storage where your LXC container's filesystem shared by Zamba will be generated (default: local-zfs)

--- a/conf/zamba.conf.example
+++ b/conf/zamba.conf.example
@@ -14,6 +14,9 @@
 # Defines the Proxmox storage where your LXC container template are stored (default: local)
 LXC_TEMPLATE_STORAGE="local"
 
+# Delault mirror setting for /etc/apt/sources.list (default: "", leaves the file unchanged)
+LXC_TEMPLATE_SET_MIRROR=""
+
 # Defines the size in GB of the LXC container's root filesystem (default: 32)
 # Depending on your environment, you should consider increasing the size for use of `mailpiler` or `matrix`.
 LXC_ROOTFS_SIZE="32"
@@ -26,6 +29,8 @@ LXC_SHAREFS_SIZE="100"
 LXC_SHAREFS_STORAGE="local-zfs"
 # Defines the mountpoint of the filesystem shared by Zamba inside your LXC container (default: tank)
 LXC_SHAREFS_MOUNTPOINT="tank"
+# Defines a the host system folder to be bind-mounted and shared by Zamba. Requires LXC_SHAREFS_SIZE > 0 but ignores the value. (AD member & standalone) (default: "")
+LXC_SHAREFS_BINDMOUNT=""
 
 # Defines the amount of RAM in MB your LXC container is allowed to use (default: 1024)
 LXC_MEM=1024

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,11 @@ fi
 sleep 2
 
 if [ $LXC_MP -gt 0 ]; then
-  pct set $LXC_NBR -mp0 $LXC_SHAREFS_STORAGE:$LXC_SHAREFS_SIZE,backup=1,mp=/$LXC_SHAREFS_MOUNTPOINT
+  if [ -z "$LXC_SHAREFS_BINDMOUNT" ]; then
+    pct set $LXC_NBR -mp0 $LXC_SHAREFS_STORAGE:$LXC_SHAREFS_SIZE,backup=1,mp=/$LXC_SHAREFS_MOUNTPOINT
+  else
+    pct set $LXC_NBR -mp0 volume=$LXC_SHAREFS_BINDMOUNT,mp=$LXC_SHAREFS_MOUNTPOINT
+  fi
 fi
 sleep 2;
 

--- a/src/lxc-base.sh
+++ b/src/lxc-base.sh
@@ -26,36 +26,41 @@ locale-gen $LXC_LOCALE
 # Generate sources
 if [ "$LXC_TEMPLATE_VERSION" == "debian-10-standard" ] ; then
 
+if [ -n "$LXC_TEMPLATE_SET_MIRROR" ]; then
 cat << EOF > /etc/apt/sources.list
-deb http://ftp.halifax.rwth-aachen.de/debian/ buster main contrib
+deb $LXC_TEMPLATE_SET_MIRROR/debian/ buster main contrib
 
-deb http://ftp.halifax.rwth-aachen.de/debian/ buster-updates main contrib
+deb $LXC_TEMPLATE_SET_MIRROR/debian/ buster-updates main contrib
 
 # security updates
 deb http://security.debian.org/debian-security buster/updates main contrib
 EOF
+fi
 
 elif [ "$LXC_TEMPLATE_VERSION" == "debian-11-standard" ] ; then
 
+if [ -n "$LXC_TEMPLATE_SET_MIRROR" ]; then
 cat << EOF > /etc/apt/sources.list
-deb http://ftp.halifax.rwth-aachen.de/debian/ bullseye main contrib
+deb $LXC_TEMPLATE_SET_MIRROR/debian/ bullseye main contrib
 
-deb http://ftp.halifax.rwth-aachen.de/debian/ bullseye-updates main contrib
+deb $LXC_TEMPLATE_SET_MIRROR/debian/ bullseye-updates main contrib
 
 # security updates
 deb http://security.debian.org/debian-security bullseye-security main contrib
 EOF
-
+fi
 elif [ "$LXC_TEMPLATE_VERSION" == "debian-12-standard" ] ; then
 
+if [ -n "$LXC_TEMPLATE_SET_MIRROR" ]; then
 cat << EOF > /etc/apt/sources.list
-deb http://ftp.halifax.rwth-aachen.de/debian/ bookworm main contrib
+deb $LXC_TEMPLATE_SET_MIRROR/debian/ bookworm main contrib
 
-deb http://ftp.halifax.rwth-aachen.de/debian/ bookworm-updates main contrib
+deb $LXC_TEMPLATE_SET_MIRROR/debian/ bookworm-updates main contrib
 
 # security updates
 deb http://security.debian.org/debian-security bookworm-security main contrib
 EOF
+fi
 
 else echo "LXC Debian Version false. Please check configuration files!" ; exit
 fi


### PR DESCRIPTION
I had a requirement to map an existing zfs filesystem into the lxc container for use with SMB sharing, so I hacked in an option.
While there, I also added a config option for setting a specific debian mirror, or make no changes the sources.list at all.