### PR TITLE
Allow multiple shares for ZMB-MEMBER

### DIFF
--- a/conf/zamba.conf.example
+++ b/conf/zamba.conf.example
@@ -114,8 +114,8 @@ ZMB_ADMIN_PASS='Start!123'
 # Name of the "domain admins" group (depends on your Active Directory language, valid on zmb-cups, lower case)
 ZMB_DOMAIN_ADMINS="domain admins"
 
-# Defines the name of your Zamba share
-ZMB_SHARE="share"
+# Defines the names of your Zamba shares in a comma separated list
+ZMB_SHARES="share1,share2"
 
 ############### Mailpiler-Section ###############
 


### PR DESCRIPTION
Closes #134 

Instead of providing
`ZMB_SHARE="share"`

Now you can provide
`ZMB_SHARES="share1,share2"`

Disadvantage: You cannot provide a comment for the share anymore.