### PR TITLE
fix: Erlaube Überschreiben von LXC_MP in zmb-standalone

### DIFF
--- a/src/zmb-standalone/constants-service.conf
+++ b/src/zmb-standalone/constants-service.conf
@@ -11,7 +11,7 @@
 LXC_TEMPLATE_VERSION="debian-13-standard"
 
 # Create sharefs mountpoint
-LXC_MP=1
+[[ -z "$LXC_MP" ]] && LXC_MP=1
 # Defines the mountpoint of the filesystem shared by Zamba inside your LXC container (default: tank)
 LXC_SHAREFS_MOUNTPOINT="tank"
 # Defines the recordsize of mp0


### PR DESCRIPTION
Derzeit ist `LXC_MP=1` in `src/zmb-standalone/constants-service.conf` hardcodiert.
Dies verhindert, dass man in der Konfigurationsdatei (z.B. `my-fs.conf`) `LXC_MP=0` setzt, um die automatische Erstellung von ZFS Volumes zu deaktivieren (z.B. wenn man existierende Datasets via Bind-Mounts nutzen möchte).

Dieser Fix erlaubt das Überschreiben der Variable, indem er prüft, ob sie bereits gesetzt ist.